### PR TITLE
Remove  dependency and instead use an isolated scope. This makes the ser...

### DIFF
--- a/angular-css-injector.js
+++ b/angular-css-injector.js
@@ -10,7 +10,7 @@ angular.module('angular.css.injector', [])
 .provider('cssInjector', ['$interpolateProvider', function($interpolateProvider) {
 	var singlePageMode = false;
 
-	function CssInjector($compile, $rootScope, $rootElement){
+	function CssInjector($compile, $rootScope){
         // Variables
         var head = angular.element(document.getElementsByTagName('head')[0]),
             scope;
@@ -27,7 +27,7 @@ angular.module('angular.css.injector', [])
         {
             if(scope === undefined)
             {
-                scope = $rootElement.scope();
+                scope = $rootScope.$new(true);
             }
         };
 
@@ -82,8 +82,8 @@ angular.module('angular.css.injector', [])
         };
 	}
 
-	this.$get = ['$compile', '$rootScope', '$rootElement', function($compile, $rootScope, $rootElement){
-		return new CssInjector($compile, $rootScope, $rootElement);
+	this.$get = ['$compile', '$rootScope', function($compile, $rootScope){
+		return new CssInjector($compile, $rootScope);
 	}];
 
 	this.setSinglePageMode = function(mode){


### PR DESCRIPTION
Removed dependency on $rootElement and instead use an isolated scope. This makes the service work without debug info [.debugInfoEnabled(false)] in Angular 1.3. Hence it is a solution to #23 .